### PR TITLE
feat: 개발용 임시 JWT 발급 API 추가 (#8)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-issue-template.md
@@ -1,3 +1,10 @@
+---
+name: Feature Request
+about: 새로운 기능을 제안합니다
+labels: feature
+assignees: ''
+---
+
 ## ✨ 작업 내용
 - (무슨 기능인지 한 줄 설명)
 

--- a/src/main/java/com/cheongmaru/domain/user/controller/DevAuthController.java
+++ b/src/main/java/com/cheongmaru/domain/user/controller/DevAuthController.java
@@ -1,0 +1,24 @@
+package com.cheongmaru.domain.user.controller;
+
+import com.cheongmaru.global.jwt.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/dev-auth")
+@Tag(name = "DevAuth", description = "개발용 임시 인증 API")
+@RequiredArgsConstructor
+public class DevAuthController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "개발용 JWT 발급", description = "입력값 없이 access token을 발급합니다 (개발 전용)")
+    @PostMapping("/mock-token")
+    public String issueMockAccessToken() {
+        String dummyEmail = "dev@cheongmaru.com";
+        String dummyRole = "USER";
+        return jwtTokenProvider.createToken(dummyEmail, dummyRole);
+    }
+}

--- a/src/main/java/com/cheongmaru/global/config/SecurityConfig.java
+++ b/src/main/java/com/cheongmaru/global/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",         // 로그인/리프레시
+                                "/api/dev-auth/**",     // 로그인 구현 시 삭제
                                 "/api/oauth2/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/src/main/java/com/cheongmaru/global/config/SwaggerConfig.java
+++ b/src/main/java/com/cheongmaru/global/config/SwaggerConfig.java
@@ -2,6 +2,9 @@ package com.cheongmaru.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.Components;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,11 +13,22 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        final String jwtSchemeName = "JWT";
 
         return new OpenAPI()
                 .info(new Info()
                         .title("청마루 API")
                         .description("청마루 프로젝트 API 명세")
-                        .version("v1.0.0"));
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList(jwtSchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(jwtSchemeName,
+                                new SecurityScheme()
+                                        .name(jwtSchemeName)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                );
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 개발용 임시 JWT 발급 API 추가 (`/api/dev-auth/mock-token`)
- Swagger에서 JWT Authorize 버튼을 통해 accessToken 입력 가능하도록 설정

## 🔗 관련 이슈
- Closes #8

## 🧪 테스트 결과
- [x] Swagger 테스트 완료

## 📝 기타 참고 사항
- Swagger UI에서 Authorize 버튼 클릭 후 토큰 입력 가능
- TODO: 로그인 완성 시 mock API 제거 예정
