### PR TITLE
feat: 로그아웃 및 자동로그인 구현 (#14)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       MYSQL_USER: cheongmaru              # 일반 사용자 계정
       MYSQL_PASSWORD: cheongmarupw        # 해당 계정의 비밀번호
     ports:
-      - "3306:3306"  # 호스트의 3306 포트를 컨테이너 3306과 연결 (MySQL 기본 포트)
+      - "3307:3306"  # 호스트의 3306 포트를 컨테이너 3306과 연결 (MySQL 기본 포트)
     volumes:
       - mysql_data:/var/lib/mysql  # DB 데이터를 컨테이너 외부에 저장 (데이터 보존)
     networks:

--- a/src/main/java/com/cheongmaru/domain/user/controller/DevAuthController.java
+++ b/src/main/java/com/cheongmaru/domain/user/controller/DevAuthController.java
@@ -39,6 +39,6 @@ public class DevAuthController {
                     .build());
         }
 
-        return jwtTokenProvider.createToken(dummyEmail, dummyRole);
+        return jwtTokenProvider.createAccessToken(dummyEmail, dummyRole);
     }
 }

--- a/src/main/java/com/cheongmaru/domain/user/controller/UserController.java
+++ b/src/main/java/com/cheongmaru/domain/user/controller/UserController.java
@@ -1,21 +1,15 @@
 package com.cheongmaru.domain.user.controller;
 
-import com.cheongmaru.global.api.ApiResult;
-import com.cheongmaru.global.jwt.JwtTokenProvider;
 import com.cheongmaru.domain.user.domain.User;
-import com.cheongmaru.domain.user.dto.AccessTokenDto;
-import com.cheongmaru.domain.user.dto.KakaoLoginRequest;
-import com.cheongmaru.domain.user.dto.KakaoProfileDto;
-import com.cheongmaru.domain.user.dto.LoginResponse;
+import com.cheongmaru.domain.user.dto.*;
+import com.cheongmaru.global.api.ApiResult;
 import com.cheongmaru.domain.user.service.KakaoService;
 import com.cheongmaru.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -25,29 +19,37 @@ public class UserController {
 
     private final KakaoService kakaoService;
     private final UserService userService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @Operation(
             summary = "카카오 로그인",
-            description = "카카오 인가 코드를 통해 로그인하고 JWT 토큰을 반환합니다."
-    )
+            description = "카카오 인가 코드를 통해 로그인하고 JWT 토큰을 반환합니다.")
     @PostMapping("/kakao")
     public ApiResult<LoginResponse> kakaoLogin(@RequestBody KakaoLoginRequest request) {
-        // 1. 인가 코드 → 액세스 토큰 요청
+
+        // 1. 인가 코드로 access token 받기
         AccessTokenDto tokenDto = kakaoService.getAccessToken(request.getCode());
 
-        // 2. 사용자 정보 조회
+        // 2. access token 으로 사용자 프로필 조회
         KakaoProfileDto kakaoProfile = kakaoService.getKakaoProfile(tokenDto.getAccessToken());
 
-        // 3. 유저 저장 or 조회
-        User user = userService.findOrCreateUser(kakaoProfile);
+        // 3. 로그인 처리 및 토큰 발급 (UserService가 모든 처리 담당)
+        LoginResponse response = userService.login(kakaoProfile);
 
-        // 4. JWT 발급
-        String accessToken = jwtTokenProvider.createToken(user.getEmail(), user.getRole().toString());
-        String refreshToken = "dummy_refresh_token"; // 추후 구현 시 교체
-
-        // 5. DTO 응답
-        LoginResponse response = new LoginResponse(user.getId(), accessToken, refreshToken);
+        // 4. 응답 반환
         return ApiResult.success(response);
     }
+
+    @Operation(summary = "AccessToken 재발급", description = "RefreshToken을 통해 AccessToken을 재발급합니다.")
+    @PostMapping("/refresh")
+    public ApiResult<ReissueResponse> refresh(@RequestBody ReissueRequest request) {
+        return ApiResult.success(userService.reissueAccessToken(request.getRefreshToken()));
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자의 refresh token을 삭제합니다.")
+    public ApiResult<?> logout(@AuthenticationPrincipal User user) {
+        userService.logout(user.getId());
+        return ApiResult.success("로그아웃 완료");
+    }
+
 }

--- a/src/main/java/com/cheongmaru/domain/user/domain/RefreshToken.java
+++ b/src/main/java/com/cheongmaru/domain/user/domain/RefreshToken.java
@@ -1,0 +1,32 @@
+package com.cheongmaru.domain.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+
+    @Column(nullable = false, length = 512, columnDefinition = "TEXT")
+    private String token;
+
+    public RefreshToken(String userId, String token) {
+        this.userId = userId;
+        this.token = token;
+    }
+
+    public void update(String newToken) {
+        this.token = newToken;
+    }
+}
+

--- a/src/main/java/com/cheongmaru/domain/user/dto/ReissueRequest.java
+++ b/src/main/java/com/cheongmaru/domain/user/dto/ReissueRequest.java
@@ -1,0 +1,8 @@
+package com.cheongmaru.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReissueRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/cheongmaru/domain/user/dto/ReissueResponse.java
+++ b/src/main/java/com/cheongmaru/domain/user/dto/ReissueResponse.java
@@ -1,0 +1,10 @@
+package com.cheongmaru.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReissueResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/cheongmaru/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/cheongmaru/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.cheongmaru.domain.user.repository;
+
+import com.cheongmaru.domain.user.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByUserId(String userId);
+    void deleteByUserId(String userId);
+}

--- a/src/main/java/com/cheongmaru/domain/user/service/UserService.java
+++ b/src/main/java/com/cheongmaru/domain/user/service/UserService.java
@@ -1,8 +1,14 @@
 package com.cheongmaru.domain.user.service;
 
+import com.cheongmaru.domain.user.domain.RefreshToken;
 import com.cheongmaru.domain.user.domain.User;
 import com.cheongmaru.domain.user.dto.KakaoProfileDto;
+import com.cheongmaru.domain.user.dto.LoginResponse;
+import com.cheongmaru.domain.user.dto.ReissueResponse;
+import com.cheongmaru.domain.user.repository.RefreshTokenRepository;
 import com.cheongmaru.domain.user.repository.UserRepository;
+import com.cheongmaru.global.jwt.JwtTokenProvider;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,9 +17,13 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    public User findOrCreateUser(KakaoProfileDto profile) {
-        return userRepository.findByKakaoId(profile.getKakaoId())
+    @Transactional
+    public LoginResponse login(KakaoProfileDto profile) {
+        // 1. 사용자 조회 또는 생성
+        User user = userRepository.findByKakaoId(profile.getKakaoId())
                 .orElseGet(() -> userRepository.save(
                         User.createFromKakao(
                                 profile.getKakaoId(),
@@ -23,5 +33,46 @@ public class UserService {
                                 profile.getGender()
                         )
                 ));
+
+        // 2. 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole().name());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
+
+        // 3. 리프레시 토큰 저장 (기존 토큰이 있으면 덮어씀)
+        refreshTokenRepository.findByUserId(user.getId())
+                .ifPresent(refreshTokenRepository::delete);
+        refreshTokenRepository.save(new RefreshToken(user.getId(), refreshToken));
+
+        // 4. 응답 반환
+        return new LoginResponse(user.getId(), accessToken, refreshToken);
     }
+
+    @Transactional
+    public ReissueResponse reissueAccessToken(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        String email = jwtTokenProvider.getClaims(refreshToken).getSubject();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        RefreshToken storedToken = refreshTokenRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("저장된 리프레시 토큰이 없습니다."));
+
+        if (!storedToken.getToken().equals(refreshToken)) {
+            throw new IllegalArgumentException("리프레시 토큰이 일치하지 않습니다.");
+        }
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getEmail(), user.getRole().name());
+        return new ReissueResponse(newAccessToken);
+    }
+
+    @Transactional
+    public void logout(String userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+
+
 }

--- a/src/main/java/com/cheongmaru/global/auth/CustomUserDetails.java
+++ b/src/main/java/com/cheongmaru/global/auth/CustomUserDetails.java
@@ -1,0 +1,39 @@
+package com.cheongmaru.global.auth;
+
+import com.cheongmaru.domain.user.domain.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList(); // 필요시 역할 넣기
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // 소셜 로그인이라면 사용 안함
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}
+

--- a/src/main/java/com/cheongmaru/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cheongmaru/global/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.cheongmaru.global.jwt;
 
+import com.cheongmaru.domain.user.domain.User;
+import com.cheongmaru.domain.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -22,6 +24,7 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -39,11 +42,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 String email = claims.getSubject();
                 String role = (String) claims.get("role");
 
-                var authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role));
+                // 실제 유저 객체 로드
+                User user = userRepository.findByEmail(email)
+                        .orElse(null); // orElseThrow 가능
 
-                var authentication = new UsernamePasswordAuthenticationToken(email, null, authorities);
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                if (user != null) {
+                    var authorities = Collections.singletonList(
+                            new SimpleGrantedAuthority("ROLE_" + role)
+                    );
+
+                    var authentication = new UsernamePasswordAuthenticationToken(user, null, authorities);
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
         }
 

--- a/src/main/java/com/cheongmaru/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/cheongmaru/global/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.cheongmaru.global.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,50 +9,68 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.spec.SecretKeySpec;
 import java.security.Key;
+import java.util.Base64;
 import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
 
-    private final String secretKey;
-    private final int expiration;
-    private Key SECRET_KEY;
+    private final Key SECRET_KEY;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
 
-    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, @Value("${jwt.expiration}") int expiration) {
-        this.secretKey = secretKey;
-        this.expiration = expiration;
-        this.SECRET_KEY = new SecretKeySpec(java.util.Base64.getDecoder().decode(secretKey), SignatureAlgorithm.HS512.getJcaName());
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-expiration}") long accessTokenExpiration,
+            @Value("${jwt.refresh-expiration}") long refreshTokenExpiration
+    ) {
+        this.SECRET_KEY = new SecretKeySpec(Base64.getDecoder().decode(secretKey), SignatureAlgorithm.HS512.getJcaName());
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
     }
 
-
-    public String createToken(String email, String role) {
+    // AccessToken 생성 코드
+    public String createAccessToken(String email, String role) {
         Claims claims = Jwts.claims().setSubject(email);
         claims.put("role", role);
         Date now = new Date();
         String token = Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime()+ expiration))
+                .setExpiration(new Date(now.getTime()+ accessTokenExpiration))
                 .signWith(SECRET_KEY)
                 .compact();
         return token;
     }
 
+    // RefreshToken 생성
+    public String createRefreshToken(String email) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenExpiration);
+
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(SECRET_KEY)
+                .compact();
+    }
+
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
+                    .setSigningKey(SECRET_KEY)
                     .build()
                     .parseClaimsJws(token);
             return true;
-        } catch (Exception e) {
+        } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
     }
 
     public Claims getClaims(String token) {
         return Jwts.parserBuilder()
-                .setSigningKey(secretKey)
+                .setSigningKey(SECRET_KEY)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,8 @@ server:
 
 jwt:
   secret: OXJvb210b25fdW5pdi5jaHVuZ2J1a25hdGlvbmFsdW5pdmVyc2l0eS5wcm9qZWN0LnRlYW0x
-  expiration: 3600000  # 1시간 (단위: 밀리초)
+  access-expiration: 3600000  # 1시간 (단위: 밀리초)
+  refresh-expiration: 604800000   # 7일
 
 
 oauth:


### PR DESCRIPTION
✨ 작업 내용

Refresh Token을 이용한 자동 로그인 API 구현
로그아웃 API 구현 (Refresh Token 삭제 처리)

🔗 관련 이슈

Open #14 

📌 확인 사항

 Swagger로 자동 로그인(POST /api/auth/refresh) 정상 동작 확인
 Swagger로 로그아웃(POST /api/auth/logout) 정상 동작 확인
 Access Token 및 Refresh Token 발급/검증 로직 정상 작동
 토큰 유효성 검증 및 예외 상황(401,403) 처리 확인

📝 기타

프론트엔드에서 인가 코드 발급만 완료되면 전체 로그인 흐름 테스트 가능
현재는 임의로 \redirect-url에서 인가코드를 가져와 테스트 진행
로그아웃 시 서버에 저장된 리프레시 토큰이 완전히 제거됨
자동 로그인 실패 시 적절한 예외 메시지와 상태 코드 반환