### PR TITLE
feat: 태그별 장소 목록 조회 기능 추가(#25)

### DIFF
--- a/src/main/java/com/cheongmaru/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/cheongmaru/domain/place/controller/PlaceController.java
@@ -1,23 +1,23 @@
 package com.cheongmaru.domain.place.controller;
 
-import com.cheongmaru.domain.place.service.PlaceService;
 import com.cheongmaru.domain.place.dto.PlaceDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
+import com.cheongmaru.domain.place.service.PlaceService;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
+@io.swagger.v3.oas.annotations.tags.Tag(name = "Place", description = "장소 관련 API")
 @RestController
 @RequestMapping("/api/places")
-@io.swagger.v3.oas.annotations.tags.Tag(name = "Place", description = "장소 관련 API")
 public class PlaceController {
-    private final PlaceService service;
 
-    public PlaceController(PlaceService service) {
-        this.service = service;
+    private final PlaceService placeService;
+
+    public PlaceController(PlaceService placeService) {
+        this.placeService = placeService;
     }
 
     @Operation(summary = "장소 목록 조회", description = "전체 장소 목록을 조회합니다.")
@@ -25,9 +25,21 @@ public class PlaceController {
             @ApiResponse(responseCode = "200", description = "성공적으로 장소 목록을 반환함"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
+    // 기존: 전체 장소 목록 조회
     @GetMapping
-    public ResponseEntity<List<PlaceDto>> getPlaces() {
-        List<PlaceDto> places = service.getAllPlaces();
-        return ResponseEntity.ok(places);
+    public List<PlaceDto> listAll() {
+        return placeService.getAllPlaces();
+    }
+
+    // ✅ 추가: 태그별 장소 목록 조회
+    @Operation(summary = "태그별 장소 목록 조회", description = "특정 태그에 해당하는 장소 목록을 조회합니다.") // Operation 추가
+    @ApiResponses(value = { // ApiResponses 추가
+            @ApiResponse(responseCode = "200", description = "성공적으로 태그별 장소 목록을 반환함"),
+            @ApiResponse(responseCode = "404", description = "태그를 찾을 수 없거나 해당 태그를 가진 장소가 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/tags")
+    public List<PlaceDto> listByTag(@RequestParam("tag") String tagName) {
+        return placeService.getPlacesByTagName(tagName);
     }
 }

--- a/src/main/java/com/cheongmaru/domain/place/domain/Place.java
+++ b/src/main/java/com/cheongmaru/domain/place/domain/Place.java
@@ -1,6 +1,9 @@
 package com.cheongmaru.domain.place.domain;
 
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import com.cheongmaru.domain.tag.domain.Tag;
 
 @Entity
 @Table(name = "places")
@@ -17,15 +20,21 @@ public class Place {
     private Integer capacity;        // 수용 인원수 (null 허용)
 
     @Column(length = 2000)
-    private String description;      // 공간 설명 (길이 늘림)
+    private String description;      // 공간 설명
 
     private double latitude;         // 위도
     private double longitude;        // 경도
 
-    // 기본 생성자 (JPA용)
+    @ManyToMany
+    @JoinTable(
+            name = "place_tag",
+            joinColumns = @JoinColumn(name = "place_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private List<Tag> tags = new ArrayList<>();
+
     protected Place() {}
 
-    // 편의 생성자 (전체 필드)
     public Place(String name, String address, Integer capacity, String description, double latitude, double longitude) {
         this.name = name;
         this.address = address;
@@ -35,7 +44,6 @@ public class Place {
         this.longitude = longitude;
     }
 
-    // Getter들
     public Long getId() { return id; }
     public String getName() { return name; }
     public String getAddress() { return address; }
@@ -43,4 +51,5 @@ public class Place {
     public String getDescription() { return description; }
     public double getLatitude() { return latitude; }
     public double getLongitude() { return longitude; }
+    public List<Tag> getTags() { return tags; }
 }

--- a/src/main/java/com/cheongmaru/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/cheongmaru/domain/place/repository/PlaceRepository.java
@@ -1,10 +1,12 @@
 package com.cheongmaru.domain.place.repository;
 
-import com.cheongmaru.domain.place.domain.Place;       // 엔티티 패키지 경로 확인!
+import com.cheongmaru.domain.place.domain.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import java.util.List;
+
 public interface PlaceRepository extends JpaRepository<Place, Long> {
-    // JpaRepository를 상속하면 findAll()이 자동으로 제공됩니다.
+
+    // 특정 태그 이름으로 장소들을 조회하는 메서드
+    List<Place> findByTags_Name(String tagName);
 }

--- a/src/main/java/com/cheongmaru/domain/place/service/PlaceService.java
+++ b/src/main/java/com/cheongmaru/domain/place/service/PlaceService.java
@@ -1,7 +1,12 @@
 package com.cheongmaru.domain.place.service;
 
-import com.cheongmaru.domain.place.repository.PlaceRepository;
+import com.cheongmaru.domain.place.domain.Place;
 import com.cheongmaru.domain.place.dto.PlaceDto;
+import com.cheongmaru.domain.place.repository.PlaceRepository;
+import com.cheongmaru.domain.tag.domain.Tag; // Tag import 추가
+import com.cheongmaru.domain.tag.repository.TagRepository; // TagRepository import 추가
+import com.cheongmaru.global.exception.CustomException; // CustomException import 추가
+import com.cheongmaru.global.exception.ErrorCode; // ErrorCode import 추가
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -9,16 +14,39 @@ import java.util.stream.Collectors;
 
 @Service
 public class PlaceService {
-    private final PlaceRepository repo;
 
-    public PlaceService(PlaceRepository repo) {
-        this.repo = repo;
+    private final PlaceRepository placeRepository;
+    private final TagRepository tagRepository; // TagRepository 주입 추가
+
+    public PlaceService(PlaceRepository placeRepository, TagRepository tagRepository) { // 생성자 수정
+        this.placeRepository = placeRepository;
+        this.tagRepository = tagRepository;
     }
 
+    // 기존: 전체 장소 목록 조회
     public List<PlaceDto> getAllPlaces() {
-        return repo.findAll().stream()
+        return placeRepository.findAll()
+                .stream()
                 .map(PlaceDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
+    // ✅ 수정: 태그 이름으로 장소 목록 조회
+    public List<PlaceDto> getPlacesByTagName(String tagName) {
+        // 1. 태그 존재 여부 확인
+        tagRepository.findByName(tagName)
+                .orElseThrow(() -> new CustomException(ErrorCode.TAG_NOT_FOUND));
+
+        // 2. 해당 태그를 가진 장소 조회
+        List<Place> places = placeRepository.findByTags_Name(tagName);
+
+        // 3. 조회된 장소가 없는 경우 예외 발생
+        if (places.isEmpty()) {
+            throw new CustomException(ErrorCode.PLACE_NOT_FOUND_BY_TAG);
+        }
+
+        return places.stream()
+                .map(PlaceDto::fromEntity)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/cheongmaru/domain/tag/controller/TagController.java
+++ b/src/main/java/com/cheongmaru/domain/tag/controller/TagController.java
@@ -1,28 +1,29 @@
 package com.cheongmaru.domain.tag.controller;
 
-import com.cheongmaru.domain.tag.domain.Tag;
+import com.cheongmaru.domain.tag.dto.TagDto;
 import com.cheongmaru.domain.tag.service.TagService;
-import com.cheongmaru.global.api.ApiResult;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Tag", description = "태그 관련 API")
 @RestController
 @RequestMapping("/api/tags")
-@io.swagger.v3.oas.annotations.tags.Tag(name = "Tag", description = "태그 관련 API")
 public class TagController {
 
     private final TagService tagService;
+
     public TagController(TagService tagService) {
         this.tagService = tagService;
     }
 
     @GetMapping
     @Operation(summary = "태그 목록 조회", description = "전체 태그 목록을 조회합니다.")
-    public ApiResult<List<Tag>> getTags() {
-        return ApiResult.success(tagService.getAllTags());
+    public List<TagDto> getTags() {
+        return tagService.getAllTags();
     }
 }

--- a/src/main/java/com/cheongmaru/domain/tag/domain/Tag.java
+++ b/src/main/java/com/cheongmaru/domain/tag/domain/Tag.java
@@ -1,8 +1,12 @@
 package com.cheongmaru.domain.tag.domain;
 
+import com.cheongmaru.domain.place.domain.Place;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -14,4 +18,7 @@ public class Tag {
     private Long id;
 
     private String name;
+
+    @ManyToMany(mappedBy = "tags")
+    private List<Place> places = new ArrayList<>();
 }

--- a/src/main/java/com/cheongmaru/domain/tag/dto/TagDto.java
+++ b/src/main/java/com/cheongmaru/domain/tag/dto/TagDto.java
@@ -1,0 +1,26 @@
+package com.cheongmaru.domain.tag.dto;
+
+import com.cheongmaru.domain.tag.domain.Tag;
+
+public class TagDto {
+
+    private Long id;
+    private String name;
+
+    public TagDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static TagDto fromEntity(Tag tag) {
+        return new TagDto(tag.getId(), tag.getName());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/cheongmaru/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/cheongmaru/domain/tag/repository/TagRepository.java
@@ -3,5 +3,8 @@ package com.cheongmaru.domain.tag.repository;
 import com.cheongmaru.domain.tag.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional; // Optional import 추가
+
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    Optional<Tag> findByName(String name); // 추가
 }

--- a/src/main/java/com/cheongmaru/domain/tag/service/TagService.java
+++ b/src/main/java/com/cheongmaru/domain/tag/service/TagService.java
@@ -1,12 +1,12 @@
 package com.cheongmaru.domain.tag.service;
 
 import com.cheongmaru.domain.tag.domain.Tag;
+import com.cheongmaru.domain.tag.dto.TagDto;
 import com.cheongmaru.domain.tag.repository.TagRepository;
-import com.cheongmaru.global.exception.CustomException;
-import com.cheongmaru.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class TagService {
@@ -17,11 +17,10 @@ public class TagService {
         this.tagRepository = tagRepository;
     }
 
-    public List<Tag> getAllTags() {
-        List<Tag> tags = tagRepository.findAll();
-        if (tags == null || tags.isEmpty()) {
-            throw new CustomException(ErrorCode.TAG_NOT_FOUND);
-        }
-        return tags;
+    public List<TagDto> getAllTags() {
+        return tagRepository.findAll()
+                .stream()
+                .map(TagDto::fromEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/cheongmaru/global/exception/ErrorCode.java
+++ b/src/main/java/com/cheongmaru/global/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,  "사용자를 찾을 수 없습니다."),
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "태그를 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
-
+    PLACE_NOT_FOUND_BY_TAG(HttpStatus.NOT_FOUND, "해당 태그를 가진 장소를 찾을 수 없습니다."),
 
 
     // 500 INTERNAL SERVER ERROR

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,4 +1,0 @@
-/*테스트 용 태그 데이터*/
-INSERT INTO tag (name) VALUES ('카페');
-INSERT INTO tag (name) VALUES ('스터디');
-INSERT INTO tag (name) VALUES ('청년공간');

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -31,3 +31,17 @@ INSERT INTO category (name) VALUES ('모집');
 INSERT INTO category (name) VALUES ('공고');
 INSERT INTO category (name) VALUES ('정보');
 INSERT INTO category (name) VALUES ('자유');
+
+
+-- 태그 데이터 삽입
+INSERT INTO tag (id, name) VALUES (1, '도서관');
+INSERT INTO tag (id, name) VALUES (2, '공유 오피스');
+INSERT INTO tag (id, name) VALUES (3, '스터디 카페');
+INSERT INTO tag (id, name) VALUES (4, '청년 지원 기관');
+INSERT INTO tag (id, name) VALUES (5, '창업지원');
+INSERT INTO tag (id, name) VALUES (6, '취업지원');
+INSERT INTO tag (id, name) VALUES (7, '문화공간');
+
+
+-- 다대다 중간 테이블 연결 임시
+INSERT INTO place_tag (place_id, tag_id) VALUES (1, 1);


### PR DESCRIPTION


---

## ✨ 작업 내용
- 태그 이름으로 장소 목록을 조회하는 기능을 추가했습니다.
- 태그를 찾을 수 없는 경우 (`TAG_NOT_FOUND`)와 해당 태그를 가진 장소가 없는 경우 (`PLACE_NOT_FOUND_BY_TAG`)에 대한 예외 처리를 구현했습니다.

## 🔗 관련 이슈
- Closes #26

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
- [x] Swagger/포스트맨 테스트 완료
    * **성공 케이스**: 존재하는 태그로 장소 목록 조회 (`GET /api/places/tags?tag=도서관`)
    * **실패 케이스 1 (TAG_NOT_FOUND)**: 존재하지 않는 태그로 조회 (`GET /api/places/tags?tag=없는태그`)
    * **실패 케이스 2 (PLACE_NOT_FOUND_BY_TAG)**: 태그는 존재하지만, 해당 태그에 연결된 장소가 없는 태그로 조회 (예: `GET /api/places/tags?tag=연결없는태그` - `import.sql`에 임시로 데이터 추가 후 테스트)

## 📝 기타 참고 사항
- `TagRepository`에 `findByName` 메서드를 추가했습니다.
- `PlaceService` 생성자에 `TagRepository` 주입 추가 및 로직을 수정했습니다.
- `ErrorCode` enum에 `TAG_NOT_FOUND` 및 `PLACE_NOT_FOUND_BY_TAG`를 추가했습니다.
- Swagger 문서에 새로운 API 및 예외 응답 코드가 반영됩니다.
- 예외 메시지와 응답 포맷이 `ApiResult`와 `GlobalExceptionHandler`를 통해 일관되게 처리되는지 확인해주세요.
- TODO: 현재 `import.sql`에 테스트용 데이터로 `place_tag`에 `place_id=1`, `tag_id=1`만 임시로 연결되어 있습니다. 다른 태그와 장소의 연결도 필요 시 추가하여 다양한 태그별 조회 테스트를 진행할 수 있습니다.

---