### PR TITLE
feat: 태그별 장소목록 조회 엔드포인트 수정(#38)

### DIFF
--- a/src/main/java/com/cheongmaru/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/cheongmaru/domain/place/controller/PlaceController.java
@@ -4,45 +4,37 @@ import com.cheongmaru.domain.place.dto.PlaceDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import org.springframework.http.ResponseEntity;
 import com.cheongmaru.domain.place.service.PlaceService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
 @io.swagger.v3.oas.annotations.tags.Tag(name = "Place", description = "장소 관련 API")
 @RestController
 @RequestMapping("/api/places")
+@RequiredArgsConstructor
 public class PlaceController {
 
     private final PlaceService placeService;
 
-    public PlaceController(PlaceService placeService) {
-        this.placeService = placeService;
-    }
-
-    @Operation(summary = "장소 목록 조회", description = "전체 장소 목록을 조회합니다.")
+    @Operation(
+            summary = "장소 목록 조회 (전체 또는 태그별)",
+            description = "전체 장소 목록을 조회하거나, 'tag' 쿼리 파라미터로 특정 태그에 해당하는 장소 목록을 조회합니다."
+    )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공적으로 장소 목록을 반환함"),
+            @ApiResponse(responseCode = "404", description = "태그를 찾을 수 없거나 해당 태그를 가진 장소가 없음 (태그 필터링 시)"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    // 기존: 전체 장소 목록 조회
     @GetMapping
-    public List<PlaceDto> listAll() {
-        return placeService.getAllPlaces();
+    public List<PlaceDto> getPlaces(@RequestParam(value = "tag", required = false) String tagName) {
+        if (tagName != null && !tagName.isEmpty()) {
+            return placeService.getPlacesByTagName(tagName);
+        } else {
+            return placeService.getAllPlaces();
+        }
     }
-
-    // 기존: 태그별 장소 목록 조회
-    @Operation(summary = "태그별 장소 목록 조회", description = "특정 태그에 해당하는 장소 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "성공적으로 태그별 장소 목록을 반환함"),
-            @ApiResponse(responseCode = "404", description = "태그를 찾을 수 없거나 해당 태그를 가진 장소가 없음"),
-            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
-    })
-    @GetMapping("/tags")
-    public List<PlaceDto> listByTag(@RequestParam("tag") String tagName) {
-        return placeService.getPlacesByTagName(tagName);
-    }
-
 
     @Operation(summary = "장소 상세 조회", description = "특정 ID에 해당하는 장소의 상세 정보를 조회합니다.")
     @ApiResponses(value = {
@@ -54,5 +46,4 @@ public class PlaceController {
     public PlaceDto getPlaceDetail(@PathVariable Long placeId) {
         return placeService.getPlaceDetail(placeId);
     }
-
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 장소 목록 조회 API 엔드포인트 통합 및 태그 필터링 기능 개선
    - 기존 `/api/places/tags?tag={tagName}` 엔드포인트를 `/api/places?tag={tagName}`으로 통합하여, 하나의 엔드포인트에서 태그 유무에 따라 전체/태그별 장소 목록 조회 가능하도록 개선했습니다.

## 🔗 관련 이슈
- Closes #38 

## 🧪 테스트 결과
- [ ] 로컬 테스트 완료
    - `GET /api/places` (전체 장소 목록 조회)
    - `GET /api/places?tag=도서관` (태그별 장소 목록 조회)
    - `GET /api/places?tag=존재하지않는태그` (404 예외 처리 확인)
- [ ] Swagger 테스트 완료
    - Swagger UI를 통해 변경된 `/api/places` 엔드포인트 동작 확인
    - Swagger을 통해 다양한 `tag` 쿼리 파라미터 값으로 테스트 완료


## 📝 기타 참고 사항
- 프론트엔드에서 요청하신 엔드포인트 통합 작업을 우선 처리했습니다.
