### PR TITLE
fix: 태그별 장소목록 조회 반환값 변환(#42)

### DIFF
--- a/src/main/java/com/cheongmaru/domain/place/dto/PlaceDto.java
+++ b/src/main/java/com/cheongmaru/domain/place/dto/PlaceDto.java
@@ -1,6 +1,9 @@
 package com.cheongmaru.domain.place.dto;
 
 import com.cheongmaru.domain.place.domain.Place;
+import com.cheongmaru.domain.tag.domain.Tag; // <-- 추가된 import 문
+import java.util.List; // <-- 추가된 import 문
+import java.util.stream.Collectors; // <-- 추가된 import 문
 
 public class PlaceDto {
     private Long id;
@@ -10,10 +13,11 @@ public class PlaceDto {
     private String description;
     private double latitude;
     private double longitude;
-    private String link; // <-- 이 부분을 추가합니다.
+    private String link;
+    private List<Long> tagIds; // <-- 새로 추가된 필드
 
     public PlaceDto(Long id, String name, String address,
-                    int capacity, String description, double latitude, double longitude, String link) { // <-- 생성자에도 link 추가
+                    int capacity, String description, double latitude, double longitude, String link, List<Long> tagIds) { // <-- 생성자 파라미터에 tagIds 추가
         this.id = id;
         this.name = name;
         this.address = address;
@@ -21,7 +25,8 @@ public class PlaceDto {
         this.description = description;
         this.latitude = latitude;
         this.longitude = longitude;
-        this.link = link; // <-- 이 부분을 추가합니다.
+        this.link = link;
+        this.tagIds = tagIds; // <-- 생성자 내부 초기화 추가
     }
 
     public static PlaceDto fromEntity(Place place) {
@@ -33,11 +38,12 @@ public class PlaceDto {
                 place.getDescription(),
                 place.getLatitude(),
                 place.getLongitude(),
-                place.getLink() // <-- link 정보를 추가합니다.
+                place.getLink(),
+                place.getTags().stream().map(Tag::getId).collect(Collectors.toList()) // <-- tagIds 값을 가져와서 설정하는 로직 추가
         );
     }
 
-    // Getter들 (link getter 추가)
+    // Getter들 (link getter는 기존에 있었고, 아래 tagIds getter가 새로 추가됨)
     public Long getId() { return id; }
     public String getName() { return name; }
     public String getAddress() { return address; }
@@ -45,5 +51,6 @@ public class PlaceDto {
     public String getDescription() { return description; }
     public double getLatitude() { return latitude; }
     public double getLongitude() { return longitude; }
-    public String getLink() { return link; } // <-- link getter 추가
+    public String getLink() { return link; }
+    public List<Long> getTagIds() { return tagIds; } // <-- 새로 추가된 getter
 }

--- a/src/main/java/com/cheongmaru/domain/place/service/PlaceService.java
+++ b/src/main/java/com/cheongmaru/domain/place/service/PlaceService.java
@@ -8,6 +8,7 @@ import com.cheongmaru.domain.tag.repository.TagRepository;
 import com.cheongmaru.global.exception.CustomException;
 import com.cheongmaru.global.exception.ErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional; // import 추가
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +25,7 @@ public class PlaceService {
     }
 
     // 기존: 전체 장소 목록 조회
+    @Transactional(readOnly = true) // <-- 이 어노테이션 추가
     public List<PlaceDto> getAllPlaces() {
         return placeRepository.findAll()
                 .stream()
@@ -32,6 +34,7 @@ public class PlaceService {
     }
 
     // 기존: 태그 이름으로 장소 목록 조회
+    @Transactional(readOnly = true) // <-- 이 어노테이션 추가
     public List<PlaceDto> getPlacesByTagName(String tagName) {
         tagRepository.findByName(tagName)
                 .orElseThrow(() -> new CustomException(ErrorCode.TAG_NOT_FOUND));
@@ -51,6 +54,7 @@ public class PlaceService {
     /**
      * 장소 상세 조회
      */
+    @Transactional(readOnly = true) // <-- 이 어노테이션 추가
     public PlaceDto getPlaceDetail(Long placeId) {
         Place place = placeRepository.findById(placeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));


### PR DESCRIPTION
## ✨ 작업 내용
\[place] 태그별 장소 목록 조회 반환값 변환 (`PlaceDto` 수정)

## 🔗 관련 이슈
Closes #42

## 🧪 테스트 결과
- \[ ] 로컬 테스트 완료
- \[ ] Swagge테스트 완료

## 📝 기타 참고 사항
- `PlaceDto`에 `tagIds` 필드 추가 및 관련 로직 수정
- `PlaceService` 내 장소 조회 메서드에 `@Transactional(readOnly = true)` 어노테이션 추가하여 `LazyInitializationException` 방지